### PR TITLE
Bump Gradle to 7.x

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,15 +21,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # JDK matrix version
-        jdk_version: [ '8', '9', '10', '11', '12', '13', '14', '15' ]
+        jdk_version: [ '8', '9', '10', '11', '12', '13', '14', '15', '16' ]
         os: [ubuntu-20.04]
         experimental: [false]
         include:
-        - os: ubuntu-20.04
-          jdk_version: 16
-          # Experimental for now due to issues with Gradle when building with JDK 16 : https://github.com/gradle/gradle/issues/13481
-          experimental: true
         - os: ubuntu-20.04
           jdk_version: 17-ea
           experimental: true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -60,11 +60,11 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 15
+      - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: 15
+          java-version: 16
 
       - uses: actions/cache@v2.1.6
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,9 +12,9 @@ on:
 jobs:
   build:
   
-    name: Test on JDK ${{ matrix.jdk_version }} and ${{ matrix.os }}
+    name: Test on JDK ${{ matrix.jdk_version }}
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-20.04
 
     continue-on-error: ${{ matrix.experimental }}
 
@@ -22,11 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         jdk_version: [ '8', '9', '10', '11', '12', '13', '14', '15', '16' ]
-        os: [ubuntu-20.04]
         experimental: [false]
         include:
-        - os: ubuntu-20.04
-          jdk_version: 17-ea
+        - jdk_version: 17-ea
           experimental: true
 
     steps:

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -48,10 +48,15 @@ ext {
     systemRulesVersion = '1.19.0'
 }
 
-sourceCompatibility = 1.8
-
 repositories {
     mavenCentral()
+}
+
+java {
+    toolchain {
+        //Forcing toolchain use to 15. Newer JDK versions cause ASMEnhancer to fail for some obscure reason
+        languageVersion = JavaLanguageVersion.of(8)
+    }
 }
 
 dependencies {

--- a/buildSrc/src/functionalTest/java/org/rm3l/datanucleus/gradle/utils/TestUtils.java
+++ b/buildSrc/src/functionalTest/java/org/rm3l/datanucleus/gradle/utils/TestUtils.java
@@ -8,9 +8,9 @@ import java.util.Arrays;
 
 public final class TestUtils {
 
-    public static final String DN_JPA_RDBMS_VERSION = "5.1.11";
+    public static final String DN_JPA_RDBMS_VERSION = "5.2.8";
     public static final String JUNIT_VERSION = "4.12";
-    public static final String H2_VERSION = "1.4.192";
+    public static final String H2_VERSION = "1.4.200";
     static final String DOMAIN_PACKAGE_NAME_IN_TEST_PROJECT = "org.rm3l.datanucleus.gradle.test.domain";
 
     private TestUtils() {
@@ -29,10 +29,10 @@ public final class TestUtils {
                                      String... arguments) {
         final String[] args;
         if (arguments == null) {
-            args = new String[]{"tasks", "--stacktrace", "--warning-mode", "all"};
+            args = new String[]{"tasks", "--info", "--warning-mode", "all"};
         } else {
             args = Arrays.copyOf(arguments, arguments.length + 3);
-            args[args.length - 3] = "--stacktrace";
+            args[args.length - 3] = "--info";
             args[args.length - 2] = "--warning-mode";
             args[args.length - 1] = "all";
         }

--- a/buildSrc/src/functionalTest/java/org/rm3l/datanucleus/gradle/utils/TestUtils.java
+++ b/buildSrc/src/functionalTest/java/org/rm3l/datanucleus/gradle/utils/TestUtils.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 
 public final class TestUtils {
 
-    public static final String DN_JPA_RDBMS_VERSION = "5.2.8";
+    public static final String DN_JPA_RDBMS_VERSION = "5.2.9";
     public static final String JUNIT_VERSION = "4.12";
     public static final String H2_VERSION = "1.4.200";
     static final String DOMAIN_PACKAGE_NAME_IN_TEST_PROJECT = "org.rm3l.datanucleus.gradle.test.domain";

--- a/buildSrc/src/main/java/org/rm3l/datanucleus/gradle/DataNucleusPlugin.java
+++ b/buildSrc/src/main/java/org/rm3l/datanucleus/gradle/DataNucleusPlugin.java
@@ -66,9 +66,7 @@ public class DataNucleusPlugin implements Plugin<Project> {
         addTask(project, SCHEMAINFO, SchemaInfoTask.class);
 
         final Logger projectLogger = project.getLogger();
-        if (projectLogger.isDebugEnabled()) {
-            projectLogger.debug("Adding DataNucleus extensions to the build [{}]", project.getName());
-        }
+        projectLogger.info("Adding DataNucleus extensions to the build [{}]", project.getName());
 
         project.getExtensions().add("datanucleus", dataNucleusExtension);
     }

--- a/buildSrc/src/main/java/org/rm3l/datanucleus/gradle/tasks/enhance/AbstractEnhanceTask.java
+++ b/buildSrc/src/main/java/org/rm3l/datanucleus/gradle/tasks/enhance/AbstractEnhanceTask.java
@@ -234,9 +234,7 @@ public abstract class AbstractEnhanceTask extends AbstractDataNucleusTask {
 
         final Boolean shouldSkip = skip;
         if (shouldSkip != null && shouldSkip) {
-            if (projectLogger.isDebugEnabled()) {
-                projectLogger.debug("Enhancement Task Execution skipped as requested");
-            }
+            projectLogger.info("Enhancement Task Execution skipped as requested");
         } else {
 
             if (persistenceUnitName == null || persistenceUnitName.trim().isEmpty()) {

--- a/buildSrc/src/main/java/org/rm3l/datanucleus/gradle/tasks/schematool/AbstractSchemaToolTask.java
+++ b/buildSrc/src/main/java/org/rm3l/datanucleus/gradle/tasks/schematool/AbstractSchemaToolTask.java
@@ -194,9 +194,7 @@ public abstract class AbstractSchemaToolTask extends AbstractDataNucleusTask {
 
         final Boolean shouldSkip = skip;
         if (shouldSkip != null && shouldSkip) {
-            if (projectLogger.isDebugEnabled()) {
-                projectLogger.debug("SchemaTool Task Execution skipped as requested");
-            }
+            projectLogger.info("SchemaTool Task Execution skipped as requested");
         } else {
 
             this.checkTaskOptionsValidity();

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Now that Gradle 7.0 officially supports JDK 16, the build should pass against this JDK.

**Commit Log**
- chore(deps): Bump Gradle to 7.0
- chore(deps): Mark JDK 16 as non-experimental
