### PR TITLE
Declare ddlFile as an output and correct option

### DIFF
--- a/buildSrc/src/functionalTest/java/org/rm3l/datanucleus/gradle/tasks/schematool/CreateDatabaseTablesTaskFTest.java
+++ b/buildSrc/src/functionalTest/java/org/rm3l/datanucleus/gradle/tasks/schematool/CreateDatabaseTablesTaskFTest.java
@@ -40,7 +40,7 @@ class CreateDatabaseTablesTaskFTest {
     void test_CreateDBTables_does_succeed(@DataNucleusPluginTestExtension.TempDir Path tempDir) throws IOException {
         final File log4jConfFile = Files.createFile(tempDir.resolve("log4j.conf")).toFile();
         final File jdkLogConfFile = Files.createFile(tempDir.resolve("jdkLog.conf")).toFile();
-        final File ddlFile = Files.createFile(tempDir.resolve("ddlFile.ddl.sql")).toFile();
+        final File ddlFile = tempDir.resolve("ddlFile.ddl.sql").toFile();
 
         final Path buildGradle = tempDir.resolve("build.gradle");
         Files.write(buildGradle,
@@ -90,7 +90,7 @@ class CreateDatabaseTablesTaskFTest {
     void test_run_createDatabaseTables_task_cli_succeeds(@DataNucleusPluginTestExtension.TempDir Path tempDir) throws IOException {
         final File log4jConfFile = Files.createFile(tempDir.resolve("log4j.conf")).toFile();
         final File jdkLogConfFile = Files.createFile(tempDir.resolve("jdkLog.conf")).toFile();
-        final File ddlFile = Files.createFile(tempDir.resolve("ddlFile.ddl.sql")).toFile();
+        final File ddlFile = tempDir.resolve("ddlFile.ddl.sql").toFile();
 
         final Path buildGradle = tempDir.resolve("build.gradle");
         Files.write(buildGradle,
@@ -132,5 +132,7 @@ class CreateDatabaseTablesTaskFTest {
         BuildTask createDatabaseTablesTask = result.task(":createDatabaseTables");
         assertNotNull(createDatabaseTablesTask);
         assertSame(SUCCESS, createDatabaseTablesTask.getOutcome());
+
+        assertNotEquals(0, ddlFile.length(), "DDL File should not be empty");
     }
 }

--- a/buildSrc/src/main/java/org/rm3l/datanucleus/gradle/tasks/schematool/AbstractSchemaToolTask.java
+++ b/buildSrc/src/main/java/org/rm3l/datanucleus/gradle/tasks/schematool/AbstractSchemaToolTask.java
@@ -145,7 +145,7 @@ public abstract class AbstractSchemaToolTask extends AbstractDataNucleusTask {
         this.completeDdl = completeDdl;
     }
 
-    @InputFile
+    @OutputFile
     @Optional
     public File getDdlFile() {
         return ddlFile;
@@ -153,7 +153,7 @@ public abstract class AbstractSchemaToolTask extends AbstractDataNucleusTask {
 
     @Option(option = "ddl-file", description = "Path to DDL file")
     public void setDdlFile(String ddlFile) {
-        this.setJdkLogConfiguration(
+        this.setDdlFile(
                 java.util.Optional.ofNullable(ddlFile).map(File::new).orElse(null));
     }
 


### PR DESCRIPTION
Change the `ddlFile` property to be an output file, it's created by the
task, otherwise the user is forced to create an empty file beforehand.
Change the respective option to call the expected setter.
Update the tests accordingly:
 - Do not create the DDL file beforehand to verify that the task does
 not require it;
 - Assert that the file has contents when the task is called with the
 CLI.