### PR TITLE
Use extension instead of deprecated convention

### DIFF
--- a/buildSrc/src/main/java/org/rm3l/datanucleus/gradle/extensions/enhance/EnhanceExtension.java
+++ b/buildSrc/src/main/java/org/rm3l/datanucleus/gradle/extensions/enhance/EnhanceExtension.java
@@ -25,7 +25,7 @@ package org.rm3l.datanucleus.gradle.extensions.enhance;
 import groovy.lang.Closure;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.util.ConfigureUtil;
@@ -71,9 +71,9 @@ public class EnhanceExtension {
         this.datanucleusExtension = datanucleusExtension;
         this.project = datanucleusExtension.getProject();
         this.skip(skip);
-        final JavaPluginConvention javaConvention =
-                project.getConvention().getPlugin(JavaPluginConvention.class);
-        this.sourceSet = javaConvention.getSourceSets().getByName(defaultSourceSetName);
+        final JavaPluginExtension javaExtension =
+                project.getExtensions().getByType(JavaPluginExtension.class);
+        this.sourceSet = javaExtension.getSourceSets().getByName(defaultSourceSetName);
     }
 
     public Boolean getSkip() {

--- a/buildSrc/src/main/java/org/rm3l/datanucleus/gradle/extensions/schematool/SchemaToolExtension.java
+++ b/buildSrc/src/main/java/org/rm3l/datanucleus/gradle/extensions/schematool/SchemaToolExtension.java
@@ -6,9 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.annotation.Nonnull;
-import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.util.ConfigureUtil;
 import org.rm3l.datanucleus.gradle.DataNucleusApi;
@@ -87,9 +85,6 @@ public class SchemaToolExtension {
 
     public SchemaToolExtension(DataNucleusExtension dataNucleusExtension) {
         this.datanucleusExtension = dataNucleusExtension;
-        Project project = dataNucleusExtension.getProject();
-        final JavaPluginConvention javaConvention =
-                project.getConvention().getPlugin(JavaPluginConvention.class);
     }
 
     public Boolean getSkip() {


### PR DESCRIPTION
Replace the usage of the deprecated `JavaPluginConvention` with `JavaPluginExtension`.
Remove unused `JavaPluginConvention` in `SchemaToolExtension`.

---
Ref: https://docs.gradle.org/7.4.1/userguide/upgrading_version_7.html#java_convention_deprecation

I assume this change is fine since the plugin is being built with Gradle 7.x and thus targeting at least version 7.