### PR TITLE
Use new property in reports configuration

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -100,8 +100,8 @@ gradlePlugin {
 jacocoTestReport {
     executionData fileTree(buildDir).include("/jacoco/*.exec")
     reports {
-        xml.enabled = true
-        html.enabled = true
+        xml.required = true
+        html.required = true
     }
 }
 


### PR DESCRIPTION
Replace the deprecated property `enabled` with `required`.

---
Ref: https://docs.gradle.org/7.4.1/dsl/org.gradle.api.reporting.Report.html#org.gradle.api.reporting.Report:enabled