### PR TITLE
Address some build deprecation warnings

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -29,9 +29,9 @@ plugins {
 apply from: "$rootDir/integration-test.gradle"
 apply from: "$rootDir/functional-test.gradle"
 
-group 'org.rm3l'
-//version '1.0.181224-SNAPSHOT'
-version '2.0.0'
+group = 'org.rm3l'
+//version = '1.0.181224-SNAPSHOT'
+version = '2.0.0'
 
 ext {
     datanucleusCoreVersion = '6.0.5'
@@ -132,9 +132,9 @@ publishing {
     publications {
         pluginPublication(MavenPublication) {
             from components.java
-            groupId project.group
-            artifactId "datanucleus-gradle-plugin"
-            version project.version
+            groupId = project.group
+            artifactId = "datanucleus-gradle-plugin"
+            version = project.version
         }
     }
 }

--- a/sample-jdo/build.gradle
+++ b/sample-jdo/build.gradle
@@ -4,10 +4,12 @@ plugins {
     id 'maven-publish'
 }
 
-group 'org.rm3l'
-version '2.0.0'
+group = 'org.rm3l'
+version = '2.0.0'
 
-sourceCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
 
 dependencies {
     implementation 'org.datanucleus:datanucleus-accessplatform-jdo-rdbms:6.0.5'

--- a/sample-jpa-multiproject/common/build.gradle
+++ b/sample-jpa-multiproject/common/build.gradle
@@ -2,10 +2,12 @@ plugins {
     id 'java'
 }
 
-group 'org.rm3l'
-version '2.0.0'
+group = 'org.rm3l'
+version = '2.0.0'
 
-sourceCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
 
 dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"

--- a/sample-jpa-multiproject/domain/build.gradle
+++ b/sample-jpa-multiproject/domain/build.gradle
@@ -4,10 +4,12 @@ plugins {
     id 'maven-publish'
 }
 
-group 'org.rm3l'
-version '2.0.0'
+group = 'org.rm3l'
+version = '2.0.0'
 
-sourceCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
 
 dependencies {
     implementation project(':sample-jpa-multiproject:common')

--- a/sample-jpa/build.gradle
+++ b/sample-jpa/build.gradle
@@ -4,10 +4,12 @@ plugins {
     id 'maven-publish'
 }
 
-group 'org.rm3l'
-version '2.0.0'
+group = 'org.rm3l'
+version = '2.0.0'
 
-sourceCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
 
 dependencies {
     implementation 'org.datanucleus:datanucleus-accessplatform-jpa-rdbms:6.0.5'


### PR DESCRIPTION
Address warnings on newer Gradle versions:
 - Properties should be assigned using the 'propName = value' syntax.
 - The `JavaPluginConvention` type has been deprecated.